### PR TITLE
Fix broken metastable_domains in chemical potential diagram

### DIFF
--- a/src/rxn_network/entries/entry_set.py
+++ b/src/rxn_network/entries/entry_set.py
@@ -481,7 +481,7 @@ class GibbsEntrySet(collections.abc.MutableSet, MSONable):
         """Returns a list of all entries in the entry set."""
         return list(sorted(self.entries, key=lambda e: e.composition.reduced_formula))
 
-    @cached_property
+    @property
     def min_entries_by_formula(self) -> Dict[str, ComputedEntry]:
         """
         Returns a dict of minimum energy entries in the entry set, indexed by


### PR DESCRIPTION
Fixes Issue #91.

**Why the bug was happening:** Part of the chemical potential surface was getting obscured due to too small of a bounding box. This was a problem for certain systems like the one discussed in the issue.