### PR TITLE
Fix equality comparison for `ExperimentalReferenceEntry` due to energy adjustments

### DIFF
--- a/src/rxn_network/entries/experimental.py
+++ b/src/rxn_network/entries/experimental.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import hashlib
+import math
 from typing import TYPE_CHECKING
 
 from monty.json import MontyDecoder
@@ -196,11 +197,14 @@ class ExperimentalReferenceEntry(ComputedEntry):
         return "\n".join(output)
 
     def __eq__(self, other) -> bool:
+        """Note: the value of the energy correction must be compared rather than
+        the object due to equality checking in EnergyAdjustment.
+        """
         if isinstance(other, self.__class__):
             return (
                 (self.composition.reduced_formula == other.composition.reduced_formula)
                 and (self.temperature == other.temperature)
-                and (set(self.energy_adjustments) == set(other.energy_adjustments))
+                and math.isclose(self.correction_per_atom, other.correction_per_atom)
             )
         return False
 

--- a/src/rxn_network/jobs/schema.py
+++ b/src/rxn_network/jobs/schema.py
@@ -1,5 +1,4 @@
 """Core definition for various task and synthesis recipe documents."""
-from datetime import datetime
 from typing import Any, Optional
 
 from pydantic import BaseModel, Field
@@ -19,7 +18,7 @@ class EntrySetDocument(BaseModel):
     """A single entry set object as produced by the GetEntrySet job."""
 
     task_label: Optional[str] = Field(None, description="The name of the task.")
-    last_updated: datetime = Field(
+    last_updated: str = Field(
         default_factory=datetime_str,
         description="Timestamp of when the document was last updated.",
     )
@@ -37,7 +36,7 @@ class EnumeratorTaskDocument(BaseModel):
     """A single task object from the reaction enumerator workflow."""
 
     task_label: Optional[str] = Field(None, description="The name of the task.")
-    last_updated: datetime = Field(
+    last_updated: str = Field(
         default_factory=datetime_str,
         description="Timestamp of when the document was last updated.",
     )
@@ -61,7 +60,7 @@ class CompetitionTaskDocument(BaseModel):
     """
 
     task_label: Optional[str] = Field(None, description="The name of the task.")
-    last_updated: datetime = Field(
+    last_updated: str = Field(
         default_factory=datetime_str,
         description="Timestamp of when the document was last updated.",
     )
@@ -97,7 +96,7 @@ class NetworkTaskDocument(BaseModel):
     """
 
     task_label: Optional[str] = Field(None, description="The name of the task.")
-    last_updated: datetime = Field(
+    last_updated: str = Field(
         default_factory=datetime_str,
         description="Timestamp of when the document was last updated.",
     )
@@ -114,7 +113,7 @@ class PathwaySolverTaskDocument(BaseModel):
     """
 
     task_label: Optional[str] = Field(None, description="The name of the task.")
-    last_updated: datetime = Field(
+    last_updated: str = Field(
         default_factory=datetime_str,
         description="Timestamp of when the document was last updated.",
     )

--- a/src/rxn_network/reactions/reaction_set.py
+++ b/src/rxn_network/reactions/reaction_set.py
@@ -308,6 +308,7 @@ class ReactionSet(MSONable):
         """
         if self.entries != rxn_set.entries:
             raise ValueError("Reaction sets must have identical entries property to combine.")
+
         open_elem = self.open_elem
         chempot = self.chempot
 

--- a/tests/entries/test_nist.py
+++ b/tests/entries/test_nist.py
@@ -134,6 +134,13 @@ def test_equals(entries):
 
     assert entry1 != entry2
 
+    entry2_copy = NISTReferenceEntry(
+        composition=comp,
+        temperature=300,
+        energy_adjustments=[ManualEnergyAdjustment(0.1)],
+    )
+    assert entry2 == entry2_copy  # ensure identical energy_adjustments are compared correctly
+
 
 def test_unique_id(entries):
     entry = entries[300]


### PR DESCRIPTION
Addresses #285.

Reaction sets should be able to be added to each other correctly now.