### PR TITLE
Add methods for recomputing a ReactionSet at a new temperature

### DIFF
--- a/src/rxn_network/reactions/computed.py
+++ b/src/rxn_network/reactions/computed.py
@@ -5,7 +5,7 @@ information about reaction thermodynamics.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Dict
 
 import numpy as np
 from uncertainties import ufloat
@@ -78,14 +78,17 @@ class ComputedReaction(BasicReaction):
             lowest_num_errors=lowest_num_errors,
         )
 
-    def get_new_temperature(self, new_temperature: float) -> ComputedReaction:
+    def get_new_temperature(self, new_temperature: float, entries_at_temp: Dict[Composition, ComputedEntry] = None) -> ComputedReaction:
         """Returns a new reaction with the temperature changed.
 
         Args:
             new_temperature: New temperature in Kelvin
         """
         try:
-            new_entries = [e.get_new_temperature(new_temperature) for e in self.entries]
+            if entries_at_temp is None:
+                new_entries = [e.get_new_temperature(new_temperature) for e in self.entries]
+            else:
+                new_entries = [entries_at_temp.get(e.composition) for e in self.entries]
         except AttributeError as e:
             raise AttributeError(
                 "One or more of the entries in the reaction is not associated with a"

--- a/src/rxn_network/reactions/computed.py
+++ b/src/rxn_network/reactions/computed.py
@@ -78,11 +78,15 @@ class ComputedReaction(BasicReaction):
             lowest_num_errors=lowest_num_errors,
         )
 
-    def get_new_temperature(self, new_temperature: float, entries_at_temp: Dict[Composition, ComputedEntry] = None) -> ComputedReaction:
+    def get_new_temperature(
+        self, new_temperature: float, entries_at_temp: dict[Composition, ComputedEntry] = None
+    ) -> ComputedReaction:
         """Returns a new reaction with the temperature changed.
 
         Args:
             new_temperature: New temperature in Kelvin
+            entries_at_temp: A map of precomputed entries to draw from when recalculating this
+                entry at a new temperature
         """
         try:
             if entries_at_temp is None:

--- a/src/rxn_network/reactions/computed.py
+++ b/src/rxn_network/reactions/computed.py
@@ -5,7 +5,7 @@ information about reaction thermodynamics.
 from __future__ import annotations
 
 from functools import cached_property
-from typing import TYPE_CHECKING, Dict
+from typing import TYPE_CHECKING
 
 import numpy as np
 from uncertainties import ufloat

--- a/src/rxn_network/reactions/open.py
+++ b/src/rxn_network/reactions/open.py
@@ -104,21 +104,23 @@ class OpenComputedReaction(ComputedReaction):
 
         return ComputedReaction(**kwargs) if not chempots else cls(chempots=chempots, **kwargs)
 
-    def get_new_temperature(self, new_temperature: float) -> OpenComputedReaction:
+    def get_new_temperature(self, new_temperature: float, entries_at_temp) -> OpenComputedReaction:
         """Returns a new reaction with the temperature changed.
 
         Args:
             new_temperature: New temperature in Kelvin
         """
         try:
-            new_entries = [e.get_new_temperature(new_temperature) for e in self.entries]
+            if entries_at_temp is None:
+                new_entries = [e.get_new_temperature(new_temperature) for e in self.entries]
+            else:
+                new_entries = [entries_at_temp.get(e.composition) for e in self.entries]
         except AttributeError as e:
             raise AttributeError(
                 "One or more of the entries in the reaction is not associated with a"
                 " temperature. Please use the GibbsComputedEntry class for all entries"
                 " in the reaction."
             ) from e
-
         return OpenComputedReaction(
             new_entries,
             self.coefficients,

--- a/src/rxn_network/reactions/open.py
+++ b/src/rxn_network/reactions/open.py
@@ -104,11 +104,14 @@ class OpenComputedReaction(ComputedReaction):
 
         return ComputedReaction(**kwargs) if not chempots else cls(chempots=chempots, **kwargs)
 
-    def get_new_temperature(self, new_temperature: float, entries_at_temp) -> OpenComputedReaction:
+    def get_new_temperature(self, new_temperature: float, entries_at_temp: dict | None) -> OpenComputedReaction:
         """Returns a new reaction with the temperature changed.
 
         Args:
             new_temperature: New temperature in Kelvin
+            entries_at_temp: A dictionary mapping entry compositions to Entry objects with energies
+                computed at the new temperature. Use this to avoid recomputing entries if you are
+                applying this method to many reactions.
         """
         try:
             if entries_at_temp is None:

--- a/src/rxn_network/reactions/plotting.py
+++ b/src/rxn_network/reactions/plotting.py
@@ -145,17 +145,7 @@ def plot_reaction_scatter(
     if plot_pareto:
         fig.add_trace(scatter)
 
-    hovertemplate = (
-        "<b>%{hovertext}</b><br>"
-        "<br><b>"
-        f"{x}"
-        "</b>: %{x:.3f}"
-        f" {x_units}"
-        "<br><b>"
-        f"{y}"
-        "</b>: %{y:.3f}"
-        f" {y_units}"
-    )
+    hovertemplate = f"<b>%{{hovertext}}</b><br><br><b>{x}</b>: %{{x:.3f}} {x_units}<br><b>{y}</b>: %{{y:.3f}} {y_units}"
 
     if z is not None:
         hovertemplate = hovertemplate + "<br><b>" + f"{z}" + "</b>: %{z:.3f}" + f" {z_units}<br>"

--- a/src/rxn_network/reactions/reaction_set.py
+++ b/src/rxn_network/reactions/reaction_set.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from functools import lru_cache
-from typing import TYPE_CHECKING, Any, List, Dict
+from typing import TYPE_CHECKING, Any
 
 import numpy as np
 import ray
@@ -540,13 +540,13 @@ class ReactionSet(MSONable):
             The new ReactionSet containing the recalculated reactions.
         """
         new_rxns = []
-        entries = { e.composition: e.get_new_temperature(new_temp) for e in self.entries }
+        entries = {e.composition: e.get_new_temperature(new_temp) for e in self.entries}
         for rxn in tqdm(list(self.get_rxns())):
             new_rxns.append(rxn.get_new_temperature(new_temp, entries))
 
         return ReactionSet.from_rxns(new_rxns, open_elem=self.open_elem, chempot=self.chempot)
 
-    def compute_at_temperatures(self, temp_list: List[int]) -> Dict[int, ReactionSet]:
+    def compute_at_temperatures(self, temp_list: list[int]) -> dict[int, ReactionSet]:
         """Recomputes reaction energies at each temperature in a list of temperatures.
 
         Args:
@@ -562,11 +562,11 @@ class ReactionSet(MSONable):
         result = {}
         for t in tqdm(temp_list, desc="Computing reaction energies..."):
             new_rxns = []
-            entries = { e.composition: e.get_new_temperature(t) for e in self.entries }
+            entries = {e.composition: e.get_new_temperature(t) for e in self.entries}
             for rxn in all_rxns:
                 new_rxns.append(rxn.get_new_temperature(t, entries))
 
-            result[t] = ReactionSet.from_rxns(new_rxns, open_elem=self.open_elem, chempot=self.chempot)        
+            result[t] = ReactionSet.from_rxns(new_rxns, open_elem=self.open_elem, chempot=self.chempot)
         return result
 
     def _get_rxns_by_indices(self, idxs) -> Iterable[ComputedReaction | OpenComputedReaction]:


### PR DESCRIPTION
Adds a new method for creating a new reaction set from an existing reaction set by re-computing the reaction energies at a new temperature.

In doing this, we also add an optional cache parameter to the Reaction object get_new_temperature method which allows for the passing of precomputed entry formation energies at specific temperatures. This allows us to avoid recomputing entry energies at the new temperature if those entries appear in multiple reactions.

This is used in ReactCA for several years now, so this PR is helpful hygiene.